### PR TITLE
Fix "module not found" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var resolve = require('path').resolve
-var bin = require('./package').bin
+var bin = require('./package.json').bin
 
 module.exports = map_obj(bin, function(v){
   return resolve(__dirname, v)


### PR DESCRIPTION
This PR fixes next error:

```
Module not found: Error: Cannot resolve 'file' or 'directory' ./package in <...>/node_modules/7zip
```
